### PR TITLE
Add material attribute to Block class

### DIFF
--- a/src/compas_dem/elements/block.py
+++ b/src/compas_dem/elements/block.py
@@ -61,10 +61,12 @@ class Block(Element):
         transformation: Optional[Transformation] = None,
         name: Optional[str] = None,
         is_support: bool = False,
+        material: Optional[str] = None,
     ) -> None:
         super().__init__(geometry=geometry, transformation=transformation, features=features, name=name)
 
         self.is_support = is_support
+        self.block_material = material
 
     # =============================================================================
     # Constructors


### PR DESCRIPTION
When serialising a Blockmodel, a material key is created based on compas_model in the JSON file. This PR adds "material" as an argument of the __init__ method of the Block class to allow deserialisation. 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
